### PR TITLE
fix: propagate conventional commit type from child repo to sync PR

### DIFF
--- a/.github/workflows/on-child-update.yml
+++ b/.github/workflows/on-child-update.yml
@@ -34,8 +34,20 @@ jobs:
           SHORT_SHA="${FULL_SHA:0:7}"
           SHORT_SHA="${SHORT_SHA:-$(date +%s | tail -c 8)}"
 
+          # Extract conventional commit type from child commit message.
+          # Falls back to "fix" if the message doesn't follow conventional commits.
+          COMMIT_MSG=$(gh api "repos/harmony-labs/${REPO_NAME}/commits/${FULL_SHA}" \
+            --jq '.commit.message' 2>/dev/null | head -1)
+          COMMIT_TYPE=$(echo "$COMMIT_MSG" | grep -oE '^(feat|fix|perf|refactor|docs|test|chore|ci|build|style)' | head -1)
+          COMMIT_TYPE="${COMMIT_TYPE:-fix}"
+          # chore/docs/test/ci/style/build don't trigger release-please — promote to fix
+          case "$COMMIT_TYPE" in
+            feat|fix|perf) ;;
+            *) COMMIT_TYPE="fix" ;;
+          esac
+
           BRANCH="sync/${REPO_NAME}/${SHORT_SHA}"
-          PR_TITLE="feat(${REPO_NAME}): sync ${SHORT_SHA}"
+          PR_TITLE="${COMMIT_TYPE}(${REPO_NAME}): sync ${SHORT_SHA}"
 
           # Check for existing branch
           if git ls-remote --exit-code origin "refs/heads/$BRANCH" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Instead of hardcoding `feat:` (or previously `chore:`), fetch the child commit message and extract the conventional commit type
- `fix:` → `fix(repo): sync` → patch bump
- `feat:` → `feat(repo): sync` → minor bump (post-1.0)
- Non-release types (`chore`, `docs`, `test`, etc.) → promoted to `fix:` so syncs always trigger a release

Addresses review feedback from #67 — `feat:` would bump minor after 1.0, but most child syncs should be patches.

This PR is also a `fix:` commit, so merging it will trigger release-please to create the release PR that includes the meta_git_cli#25 fix.

## Test plan

- [ ] Verify `gh api repos/harmony-labs/REPO/commits/SHA --jq '.commit.message'` returns the commit message
- [ ] Child `fix:` push → sync PR title starts with `fix(`
- [ ] Child `feat:` push → sync PR title starts with `feat(`
- [ ] Child `chore:` push → sync PR title starts with `fix(` (promoted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated sync pull request titles to dynamically reflect the type of change being synced from child repositories, providing better visibility into update categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->