### PR TITLE
fix: stricter regex and better error logging for sync PR commit type

### DIFF
--- a/.github/workflows/on-child-update.yml
+++ b/.github/workflows/on-child-update.yml
@@ -36,12 +36,15 @@ jobs:
 
           # Extract conventional commit type from child commit message.
           # Falls back to "fix" if the message doesn't follow conventional commits.
+          GH_ERR=$(mktemp)
           COMMIT_MSG=$(gh api "repos/harmony-labs/${REPO_NAME}/commits/${FULL_SHA}" \
-            --jq '.commit.message' 2>&1 | head -1) || true
-          if [[ -z "$COMMIT_MSG" || "$COMMIT_MSG" == *"Not Found"* || "$COMMIT_MSG" == *"Bad credentials"* ]]; then
-            echo "Warning: could not fetch commit message for ${REPO_NAME}@${FULL_SHA}, defaulting to fix:"
+            --jq '.commit.message' 2>"$GH_ERR" | head -1)
+          GH_EXIT=$?
+          if [[ $GH_EXIT -ne 0 || -z "$COMMIT_MSG" ]]; then
+            echo "Warning: could not fetch commit message for ${REPO_NAME}@${FULL_SHA} (exit $GH_EXIT: $(head -1 "$GH_ERR")), defaulting to fix:"
             COMMIT_MSG=""
           fi
+          rm -f "$GH_ERR"
           # Match type followed by optional scope and colon: feat:, fix(scope):, etc.
           COMMIT_TYPE=$(echo "$COMMIT_MSG" | grep -oE '^(feat|fix|perf|refactor|docs|test|chore|ci|build|style)(\([^)]+\))?:' | grep -oE '^[a-z]+' | head -1)
           COMMIT_TYPE="${COMMIT_TYPE:-fix}"

--- a/.github/workflows/on-child-update.yml
+++ b/.github/workflows/on-child-update.yml
@@ -37,8 +37,13 @@ jobs:
           # Extract conventional commit type from child commit message.
           # Falls back to "fix" if the message doesn't follow conventional commits.
           COMMIT_MSG=$(gh api "repos/harmony-labs/${REPO_NAME}/commits/${FULL_SHA}" \
-            --jq '.commit.message' 2>/dev/null | head -1)
-          COMMIT_TYPE=$(echo "$COMMIT_MSG" | grep -oE '^(feat|fix|perf|refactor|docs|test|chore|ci|build|style)' | head -1)
+            --jq '.commit.message' 2>&1 | head -1) || true
+          if [[ -z "$COMMIT_MSG" || "$COMMIT_MSG" == *"Not Found"* || "$COMMIT_MSG" == *"Bad credentials"* ]]; then
+            echo "Warning: could not fetch commit message for ${REPO_NAME}@${FULL_SHA}, defaulting to fix:"
+            COMMIT_MSG=""
+          fi
+          # Match type followed by optional scope and colon: feat:, fix(scope):, etc.
+          COMMIT_TYPE=$(echo "$COMMIT_MSG" | grep -oE '^(feat|fix|perf|refactor|docs|test|chore|ci|build|style)(\([^)]+\))?:' | grep -oE '^[a-z]+' | head -1)
           COMMIT_TYPE="${COMMIT_TYPE:-fix}"
           # chore/docs/test/ci/style/build don't trigger release-please — promote to fix
           case "$COMMIT_TYPE" in

--- a/.github/workflows/on-child-update.yml
+++ b/.github/workflows/on-child-update.yml
@@ -37,9 +37,9 @@ jobs:
           # Extract conventional commit type from child commit message.
           # Falls back to "fix" if the message doesn't follow conventional commits.
           GH_ERR=$(mktemp)
-          COMMIT_MSG=$(gh api "repos/harmony-labs/${REPO_NAME}/commits/${FULL_SHA}" \
-            --jq '.commit.message' 2>"$GH_ERR" | head -1)
-          GH_EXIT=$?
+          RAW_COMMIT_MSG=$(gh api "repos/harmony-labs/${REPO_NAME}/commits/${FULL_SHA}" \
+            --jq '.commit.message' 2>"$GH_ERR") && GH_EXIT=0 || GH_EXIT=$?
+          COMMIT_MSG=$(printf '%s\n' "$RAW_COMMIT_MSG" | head -1)
           if [[ $GH_EXIT -ne 0 || -z "$COMMIT_MSG" ]]; then
             echo "Warning: could not fetch commit message for ${REPO_NAME}@${FULL_SHA} (exit $GH_EXIT: $(head -1 "$GH_ERR")), defaulting to fix:"
             COMMIT_MSG=""


### PR DESCRIPTION
## Summary

Addresses review comments from #69:

- **Regex false positives**: The pattern matched keyword prefixes without requiring `:` after the type (e.g. `"feature: add login"` matched as `feat`). Now requires `type(scope)?:` format.
- **Silent API failures**: `2>/dev/null` swallowed errors from `gh api`. Now logs a warning when commit message fetch fails.

## Test plan

- [ ] `"fix: some change"` → extracts `fix`
- [ ] `"feat(scope): thing"` → extracts `feat`
- [ ] `"feature: wrong keyword"` → no match → defaults to `fix`
- [ ] `"testing the pipeline"` → no match → defaults to `fix`
- [ ] Failed API call → logs warning, defaults to `fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved resilience of commit-message extraction in CI by adding robust error handling and a safe fallback when extraction fails.
  * Treats missing or failed extraction as a non-fatal warning and defaults to a safe commit type.
  * Adds support for parsing conventional commit type strings with optional scopes (e.g., fix(scope):) to improve commit categorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->