### PR TITLE
Align workspace after meta agent removal

### DIFF
--- a/.claude/rules/meta-destructive-commands.md
+++ b/.claude/rules/meta-destructive-commands.md
@@ -19,7 +19,7 @@ Multi-repo workspaces amplify the impact of destructive commands.
    meta --include api-service exec -- git reset --hard
    ```
 
-## Blocked by `meta agent guard`
+## Blocked by `agent guard`
 
 These commands trigger PreToolUse denial:
 - `git push --force` (use `--force-with-lease` instead)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,7 +936,6 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
- "dirs",
  "env_logger",
  "flate2",
  "indexmap",
@@ -946,14 +945,12 @@ dependencies = [
  "meta_plugin_protocol",
  "predicates 2.1.5",
  "rayon",
- "regex",
  "serde",
  "serde_json",
  "serde_yaml",
  "tar",
  "tempfile",
  "thiserror",
- "toml",
  "ureq",
  "walkdir",
  "zip",
@@ -1515,15 +1512,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1754,47 +1742,6 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "typenum"
@@ -2203,15 +2150,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -86,6 +86,8 @@ teardown() {
     [ "$status" -eq 0 ]
     run grep "agent guard" .claude/settings.json
     [ "$status" -eq 0 ]
+    run grep "meta agent guard" .claude/settings.json
+    [ "$status" -ne 0 ]
 }
 
 @test "init claude PreToolUse has Bash matcher" {

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -81,10 +81,10 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
-@test "init claude settings references meta agent guard" {
+@test "init claude settings references agent guard" {
     run "$META_BIN" init claude
     [ "$status" -eq 0 ]
-    run grep "meta agent guard" .claude/settings.json
+    run grep "agent guard" .claude/settings.json
     [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## Summary

- update the workspace lockfile after removing `meta_cli` guard dependencies
- update top-level `init.bats` expectations from `meta agent guard` to `agent guard`
- align top-level Claude safety wording with the standalone `agent` command

## Companion PR

- gitkb/meta_cli#24

## Verification

- `cargo test -p meta`
- `bats tests/init.bats`
- `./target/debug/meta --help` no longer lists `agent`
- `./target/debug/meta agent guard` exits unrecognized

Task: [[tasks/harmony-678]]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified safety rules wording: the blocked-by guidance now appears under “Blocked by `agent guard`” to clarify which guard enforces denials for destructive operations.
* **Tests**
  * Updated integration test expectations to look for “agent guard” and assert that “meta agent guard” is no longer present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gitkb/meta/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->