### PR TITLE
test: cover meta help routing

### DIFF
--- a/.github/scripts/clone-child-repos.sh
+++ b/.github/scripts/clone-child-repos.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+child_branch="${META_CHILD_BRANCH:-${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-}}}"
+
+branch_candidates=()
+if [[ -n "$child_branch" ]]; then
+  branch_candidates+=("$child_branch")
+
+  normalized_branch="${child_branch//\//-}"
+  if [[ "$normalized_branch" != "$child_branch" ]]; then
+    branch_candidates+=("$normalized_branch")
+  fi
+fi
+
+clone_child() {
+  local repo="$1"
+  local url="https://github.com/gitkb/${repo}.git"
+  local branch
+  local ls_remote_output
+  local ls_remote_status
+
+  for branch in "${branch_candidates[@]}"; do
+    set +e
+    ls_remote_output="$(git ls-remote --exit-code --heads "$url" "$branch" 2>&1)"
+    ls_remote_status=$?
+    set -e
+
+    if [[ $ls_remote_status -eq 0 ]]; then
+      echo "Cloning ${repo} from branch ${branch}"
+      git clone --depth 1 --branch "$branch" "$url"
+      return
+    fi
+
+    if [[ $ls_remote_status -ne 2 ]]; then
+      echo "Failed to query branch '${branch}' for ${repo} (status: ${ls_remote_status})" >&2
+      if [[ -n "$ls_remote_output" ]]; then
+        echo "$ls_remote_output" >&2
+      fi
+      exit "$ls_remote_status"
+    fi
+  done
+
+  echo "Cloning ${repo} from default branch"
+  git clone --depth 1 "$url"
+}
+
+clone_child loop_lib
+clone_child loop_cli
+clone_child meta_cli
+clone_child meta_core
+clone_child meta_git_cli
+clone_child meta_git_lib
+clone_child meta_mcp
+clone_child meta_plugin_protocol
+clone_child meta_rust_cli
+clone_child meta_project_cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,18 +24,7 @@ jobs:
 
       - name: Clone child repos
         shell: bash
-        run: |
-          # Clone all workspace member repos (meta-repo architecture)
-          git clone --depth 1 https://github.com/gitkb/loop_lib.git
-          git clone --depth 1 https://github.com/gitkb/loop_cli.git
-          git clone --depth 1 https://github.com/gitkb/meta_cli.git
-          git clone --depth 1 https://github.com/gitkb/meta_core.git
-          git clone --depth 1 https://github.com/gitkb/meta_git_cli.git
-          git clone --depth 1 https://github.com/gitkb/meta_git_lib.git
-          git clone --depth 1 https://github.com/gitkb/meta_mcp.git
-          git clone --depth 1 https://github.com/gitkb/meta_plugin_protocol.git
-          git clone --depth 1 https://github.com/gitkb/meta_rust_cli.git
-          git clone --depth 1 https://github.com/gitkb/meta_project_cli.git
+        run: .github/scripts/clone-child-repos.sh
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -56,17 +45,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Clone child repos
-        run: |
-          git clone --depth 1 https://github.com/gitkb/loop_lib.git
-          git clone --depth 1 https://github.com/gitkb/loop_cli.git
-          git clone --depth 1 https://github.com/gitkb/meta_cli.git
-          git clone --depth 1 https://github.com/gitkb/meta_core.git
-          git clone --depth 1 https://github.com/gitkb/meta_git_cli.git
-          git clone --depth 1 https://github.com/gitkb/meta_git_lib.git
-          git clone --depth 1 https://github.com/gitkb/meta_mcp.git
-          git clone --depth 1 https://github.com/gitkb/meta_plugin_protocol.git
-          git clone --depth 1 https://github.com/gitkb/meta_rust_cli.git
-          git clone --depth 1 https://github.com/gitkb/meta_project_cli.git
+        run: .github/scripts/clone-child-repos.sh
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -93,17 +72,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Clone child repos
-        run: |
-          git clone --depth 1 https://github.com/gitkb/loop_lib.git
-          git clone --depth 1 https://github.com/gitkb/loop_cli.git
-          git clone --depth 1 https://github.com/gitkb/meta_cli.git
-          git clone --depth 1 https://github.com/gitkb/meta_core.git
-          git clone --depth 1 https://github.com/gitkb/meta_git_cli.git
-          git clone --depth 1 https://github.com/gitkb/meta_git_lib.git
-          git clone --depth 1 https://github.com/gitkb/meta_mcp.git
-          git clone --depth 1 https://github.com/gitkb/meta_plugin_protocol.git
-          git clone --depth 1 https://github.com/gitkb/meta_rust_cli.git
-          git clone --depth 1 https://github.com/gitkb/meta_project_cli.git
+        run: .github/scripts/clone-child-repos.sh
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -144,17 +113,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Clone child repos
-        run: |
-          git clone --depth 1 https://github.com/gitkb/loop_lib.git
-          git clone --depth 1 https://github.com/gitkb/loop_cli.git
-          git clone --depth 1 https://github.com/gitkb/meta_cli.git
-          git clone --depth 1 https://github.com/gitkb/meta_core.git
-          git clone --depth 1 https://github.com/gitkb/meta_git_cli.git
-          git clone --depth 1 https://github.com/gitkb/meta_git_lib.git
-          git clone --depth 1 https://github.com/gitkb/meta_mcp.git
-          git clone --depth 1 https://github.com/gitkb/meta_plugin_protocol.git
-          git clone --depth 1 https://github.com/gitkb/meta_rust_cli.git
-          git clone --depth 1 https://github.com/gitkb/meta_project_cli.git
+        run: .github/scripts/clone-child-repos.sh
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,7 +936,6 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
- "dirs",
  "env_logger",
  "flate2",
  "indexmap",
@@ -946,14 +945,12 @@ dependencies = [
  "meta_plugin_protocol",
  "predicates 2.1.5",
  "rayon",
- "regex",
  "serde",
  "serde_json",
  "serde_yaml",
  "tar",
  "tempfile",
  "thiserror",
- "toml",
  "ureq",
  "walkdir",
  "zip",
@@ -1515,15 +1512,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1754,47 +1742,6 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "typenum"
@@ -2203,15 +2150,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/tests/help.bats
+++ b/tests/help.bats
@@ -1,0 +1,184 @@
+#!/usr/bin/env bats
+
+setup() {
+    META_BIN="$BATS_TEST_DIRNAME/../target/debug/meta"
+    META_GIT_BIN="$BATS_TEST_DIRNAME/../target/debug/meta-git"
+    META_PROJECT_BIN="$BATS_TEST_DIRNAME/../target/debug/meta-project"
+    META_RUST_BIN="$BATS_TEST_DIRNAME/../target/debug/meta-rust"
+
+    if [ ! -f "$META_BIN" ] || [ ! -f "$META_GIT_BIN" ] || [ ! -f "$META_PROJECT_BIN" ] || [ ! -f "$META_RUST_BIN" ]; then
+        cargo build --workspace --quiet
+    fi
+
+    TEST_DIR="$(mktemp -d)"
+    NO_CONFIG_DIR="$(mktemp -d)"
+    mkdir -p "$TEST_DIR/.meta/plugins" "$TEST_DIR/api" "$TEST_DIR/web"
+    mkdir -p "$NO_CONFIG_DIR/.meta/plugins"
+    cp "$META_GIT_BIN" "$TEST_DIR/.meta/plugins/meta-git"
+    cp "$META_PROJECT_BIN" "$TEST_DIR/.meta/plugins/meta-project"
+    cp "$META_RUST_BIN" "$TEST_DIR/.meta/plugins/meta-rust"
+    cp "$META_GIT_BIN" "$NO_CONFIG_DIR/.meta/plugins/meta-git"
+    cp "$META_RUST_BIN" "$NO_CONFIG_DIR/.meta/plugins/meta-rust"
+    chmod +x "$TEST_DIR/.meta/plugins/meta-git" "$TEST_DIR/.meta/plugins/meta-project" "$TEST_DIR/.meta/plugins/meta-rust"
+    chmod +x "$NO_CONFIG_DIR/.meta/plugins/meta-git"
+    chmod +x "$NO_CONFIG_DIR/.meta/plugins/meta-rust"
+
+    cat > "$TEST_DIR/.meta.json" <<'JSON'
+{
+    "projects": {
+        "api": "git@github.com:org/api.git",
+        "web": "git@github.com:org/web.git"
+    }
+}
+JSON
+
+    cd "$TEST_DIR"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+    rm -rf "$NO_CONFIG_DIR"
+}
+
+@test "meta help is plugin-aware and matches meta --help" {
+    run "$META_BIN" --help
+    [ "$status" -eq 0 ]
+    help_flag="$output"
+
+    run "$META_BIN" help
+    [ "$status" -eq 0 ]
+    [ "$output" = "$help_flag" ]
+    [[ "$output" == *"git"* ]]
+    [[ "$output" == *"project"* ]]
+}
+
+@test "built-in command help does not execute commands" {
+    run "$META_BIN" context --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage: meta context"* ]]
+    [[ "$output" != *"# Meta Workspace"* ]]
+
+    run "$META_BIN" plugin search --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage: meta plugin search <QUERY>"* ]]
+    [[ "$output" != *"required arguments were not provided"* ]]
+
+    run "$META_BIN" plugin list --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage: meta plugin list"* ]]
+    [[ "$output" != *"Installed plugins"* ]]
+}
+
+@test "git worktree help reaches worktree command implementation" {
+    run "$META_BIN" git worktree --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Manage git worktrees across repos"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+    [[ "$output" != *"Adapted Commands"* ]]
+
+    run "$META_BIN" git worktree create --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"create"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+
+    run "$META_BIN" git worktree list --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"list"* ]]
+}
+
+@test "nested plugin help does not require a meta config" {
+    cd "$NO_CONFIG_DIR"
+
+    run "$META_BIN" git worktree --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Manage git worktrees across repos"* ]]
+
+    run "$META_BIN" git pull --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Pass-through git command"* ]]
+    [[ "$output" == *"Current scope:"* ]]
+}
+
+@test "rust and cargo help use the simple plugin help without side effects" {
+    cd "$NO_CONFIG_DIR"
+
+    for command in "cargo --help" "cargo build --help" "rust --help" "rust build --help"; do
+        run "$META_BIN" $command
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"meta cargo <command>"* ]]
+        [[ "$output" == *"Build all Rust projects"* ]]
+        [[ "$output" != *"Could not find meta config"* ]]
+        [[ "$output" != *"No Rust projects found"* ]]
+    done
+}
+
+@test "git snapshot help reaches snapshot command implementation" {
+    run "$META_BIN" git snapshot --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Workspace State Management"* ]]
+    [[ "$output" != *"Adapted Commands"* ]]
+
+    run "$META_BIN" git snapshot create --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"meta git snapshot create"* ]]
+    [[ "$output" == *"Save workspace git state"* ]]
+    [[ "$output" != *"Adapted Commands"* ]]
+}
+
+@test "git pass-through help is meta-aware" {
+    for subcommand in pull fetch checkout; do
+        run "$META_BIN" git "$subcommand" --help
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"Pass-through git command"* ]]
+        [[ "$output" == *"Runs \`git $subcommand\` in each repo"* ]]
+        [[ "$output" == *"Current scope:"* ]]
+        [[ "$output" == *"--dry-run"* ]]
+        [[ "$output" == *"--recursive"* ]]
+        [[ "$output" != *"Adapted Commands"* ]]
+    done
+}
+
+@test "project child command help is explicit and agent-oriented" {
+    run "$META_BIN" project list --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"meta project list"* ]]
+    [[ "$output" == *"Agent hints:"* ]]
+    [[ "$output" == *"--recursive --json"* ]]
+
+    run "$META_BIN" project check --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"meta project check"* ]]
+    [[ "$output" == *"missing"* ]]
+
+    run "$META_BIN" project dependents --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"meta project dependents"* ]]
+    [[ "$output" == *"blast radius"* ]]
+}
+
+@test "worktree create dry-run prints planned custom operations" {
+    git init --quiet
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    touch README.md
+    git add README.md
+    git commit --quiet -m "init root"
+
+    for repo in api web; do
+        git -C "$repo" init --quiet
+        git -C "$repo" config user.email "test@test.com"
+        git -C "$repo" config user.name "Test"
+        touch "$repo/README.md"
+        git -C "$repo" add README.md
+        git -C "$repo" commit --quiet -m "init $repo"
+    done
+
+    run "$META_BIN" --dry-run git worktree create preview --repo api
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY RUN] Would create worktree set 'preview'"* ]]
+    [[ "$output" == *"api:"* ]]
+    [[ "$output" == *"bash:"* ]]
+    [ ! -d "$TEST_DIR/.worktrees/preview" ]
+}


### PR DESCRIPTION
## Summary
- add BATS coverage for plugin-aware top-level help, built-in help, nested git worktree/snapshot help, pass-through git help, project help, rust/cargo help, and worktree create dry-run
- asserts command identity in output, not only exit codes

## Verification
- cargo fmt --all
- cargo test -q --workspace
- cargo build --workspace --quiet
- bats tests/help.bats

Depends on the companion child-repo PRs for meta_cli, meta_git_cli, meta_project_cli, and meta_rust_cli.

Implements [[tasks/harmony-677]]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests that validate help output across commands, subcommands, and plugins, and integration-style dry-run tests that confirm planned operations are reported without side effects
* **Chores**
  * Added a shared script to clone required child repositories and updated CI to use this centralized cloning step instead of inline clones

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gitkb/meta/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->