### PR TITLE
fix: use PAT for release-please PR updates

### DIFF
--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -30,6 +30,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.PARENT_REPO_PAT }}
           # Use manifest mode to track version in VERSION file
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- pass the org automation PAT into release-please-action
- keep the existing release dispatch token unchanged

## Why
Release Please PR updates made with the default GITHUB_TOKEN do not trigger downstream CI on the generated release PR. Using the established PARENT_REPO_PAT secret lets future release-please branch updates trigger checks.

## Validation
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation workflow configuration to enhance security measures for internal deployment processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gitkb/meta/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->