### PR TITLE
chore: add Codex plugins marketplace repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ meta_plugin_protocol/
 meta_project_cli/
 meta_rust_cli/
 claude-plugins/
+codex-plugins/
 meta-plugins/
 
 # plugins (built locally, not committed)

--- a/.meta.yaml
+++ b/.meta.yaml
@@ -54,5 +54,8 @@ projects:
   claude-plugins:
     repo: git@github.com:gitkb/claude-plugins.git
 
+  codex-plugins:
+    repo: git@github.com:gitkb/codex-plugins.git
+
   meta-plugins:
     repo: git@github.com:gitkb/meta-plugins.git


### PR DESCRIPTION
Adds codex-plugins to the meta CLI repo graph beside claude-plugins and ignores the new child repository checkout.\n\nValidation:\n- meta project list --recursive shows open-source/meta/codex-plugins\n- codex plugin marketplace/add smoke tests passed against isolated CODEX_HOME

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new plugins project to the workspace configuration, making it available alongside existing projects.

* **Chores**
  * Updated ignore settings to exclude plugin-related files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->