### PR TITLE
fix: remove Codex marketplace from meta graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,6 @@ meta_plugin_protocol/
 meta_project_cli/
 meta_rust_cli/
 claude-plugins/
-codex-plugins/
 meta-plugins/
 
 # plugins (built locally, not committed)

--- a/.meta.yaml
+++ b/.meta.yaml
@@ -54,8 +54,5 @@ projects:
   claude-plugins:
     repo: git@github.com:gitkb/claude-plugins.git
 
-  codex-plugins:
-    repo: git@github.com:gitkb/codex-plugins.git
-
   meta-plugins:
     repo: git@github.com:gitkb/meta-plugins.git


### PR DESCRIPTION
Removes the Codex plugin marketplace repo from gitkb/meta. Codex plugin repos belong under the clients meta graph, matching the existing client/plugin ownership boundary.\n\nValidation:\n- git diff --check