### PR TITLE
fix(hooks): isolate Git-local test environment

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -32,6 +32,22 @@ if [ -z "$WORKSPACE_ROOT" ]; then
     exit 0
 fi
 
+GIT_LOCAL_ENV_VARS=$(git rev-parse --local-env-vars) || {
+    echo "Error: Could not determine repository-local Git environment"
+    exit 1
+}
+for git_env_var in $GIT_LOCAL_ENV_VARS; do
+    case "$git_env_var" in
+        *[!A-Z0-9_]*|'')
+            echo "Error: Refusing invalid Git environment variable name: $git_env_var"
+            exit 1
+            ;;
+        *)
+            unset "$git_env_var"
+            ;;
+    esac
+done
+
 cd "$WORKSPACE_ROOT"
 
 echo "Running pre-push checks from $WORKSPACE_ROOT..."

--- a/tests/context.bats
+++ b/tests/context.bats
@@ -1,8 +1,11 @@
 #!/usr/bin/env bats
 
+load "${BATS_TEST_DIRNAME}/helpers/git_environment.bash"
+
 # Integration tests for `meta context`
 
 setup() {
+    clear_git_local_env
     META_BIN="$BATS_TEST_DIRNAME/../target/debug/meta"
 
     if [ ! -f "$META_BIN" ]; then

--- a/tests/exec.bats
+++ b/tests/exec.bats
@@ -1,9 +1,12 @@
 #!/usr/bin/env bats
 
+load "${BATS_TEST_DIRNAME}/helpers/git_environment.bash"
+
 # Integration tests for `meta exec` and loop pass-through options
 # Tests: exec, --include, --exclude, --parallel, --dry-run, --tag
 
 setup() {
+    clear_git_local_env
     META_BIN="$BATS_TEST_DIRNAME/../target/debug/meta"
     META_GIT_BIN="$BATS_TEST_DIRNAME/../target/debug/meta-git"
 

--- a/tests/git.bats
+++ b/tests/git.bats
@@ -1,9 +1,12 @@
 #!/usr/bin/env bats
 
+load "${BATS_TEST_DIRNAME}/helpers/git_environment.bash"
+
 # Integration tests for `meta git` commands
 # Tests use local git repos (no network IO required)
 
 setup() {
+    clear_git_local_env
     # Build binaries if not already built
     META_BIN="$BATS_TEST_DIRNAME/../target/debug/meta"
     META_GIT_BIN="$BATS_TEST_DIRNAME/../target/debug/meta-git"
@@ -376,7 +379,7 @@ assert backend['dirty'] == True, f'backend should be dirty, got {backend}'
 @test "meta git clone from local path works" {
     # Create a "remote" bare repo that IS a meta repo
     REMOTE_DIR="$(mktemp -d)"
-    git -C "$REMOTE_DIR" init --bare --quiet
+    git init --bare --quiet "$REMOTE_DIR"
     git -C "$REMOTE_DIR" symbolic-ref HEAD refs/heads/main
 
     # Create a temp working copy to push initial meta content
@@ -415,7 +418,7 @@ EOF
 
     # Create a "remote" bare repo with main as default branch
     REMOTE_DIR="$(mktemp -d)"
-    git -C "$REMOTE_DIR" init --bare --quiet
+    git init --bare --quiet "$REMOTE_DIR"
     git -C "$REMOTE_DIR" symbolic-ref HEAD refs/heads/main
 
     # Create a temp working copy to push initial content
@@ -457,7 +460,7 @@ EOF
 
     # Create a "remote" bare repo with main as default branch
     REMOTE_DIR="$(mktemp -d)"
-    git -C "$REMOTE_DIR" init --bare --quiet
+    git init --bare --quiet "$REMOTE_DIR"
     git -C "$REMOTE_DIR" symbolic-ref HEAD refs/heads/main
 
     # Push minimal content
@@ -489,7 +492,7 @@ EOF
 @test "meta git clone with --depth option" {
     # Create a "remote" bare repo with main as default branch
     REMOTE_DIR="$(mktemp -d)"
-    git -C "$REMOTE_DIR" init --bare --quiet
+    git init --bare --quiet "$REMOTE_DIR"
     git -C "$REMOTE_DIR" symbolic-ref HEAD refs/heads/main
 
     WORK_DIR="$(mktemp -d)"

--- a/tests/help.bats
+++ b/tests/help.bats
@@ -1,6 +1,9 @@
 #!/usr/bin/env bats
 
+load "${BATS_TEST_DIRNAME}/helpers/git_environment.bash"
+
 setup() {
+    clear_git_local_env
     META_BIN="$BATS_TEST_DIRNAME/../target/debug/meta"
     META_GIT_BIN="$BATS_TEST_DIRNAME/../target/debug/meta-git"
     META_PROJECT_BIN="$BATS_TEST_DIRNAME/../target/debug/meta-project"

--- a/tests/helpers/git_environment.bash
+++ b/tests/helpers/git_environment.bash
@@ -1,8 +1,14 @@
 clear_git_local_env() {
-    local git_env_var
+    local git_env_var git_local_env_vars
+    git_local_env_vars="$(git rev-parse --local-env-vars)" || {
+        echo "Error: Could not determine repository-local Git environment" >&2
+        return 1
+    }
     while IFS= read -r git_env_var; do
-        if [[ "$git_env_var" =~ ^[A-Z0-9_]+$ ]]; then
-            unset "$git_env_var"
+        if [[ ! "$git_env_var" =~ ^[A-Z0-9_]+$ ]]; then
+            echo "Error: Refusing invalid Git environment variable name: $git_env_var" >&2
+            return 1
         fi
-    done < <(git rev-parse --local-env-vars)
+        unset "$git_env_var"
+    done <<< "$git_local_env_vars"
 }

--- a/tests/helpers/git_environment.bash
+++ b/tests/helpers/git_environment.bash
@@ -1,0 +1,8 @@
+clear_git_local_env() {
+    local git_env_var
+    while IFS= read -r git_env_var; do
+        if [[ "$git_env_var" =~ ^[A-Z0-9_]+$ ]]; then
+            unset "$git_env_var"
+        fi
+    done < <(git rev-parse --local-env-vars)
+}

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+
+load "${BATS_TEST_DIRNAME}/helpers/git_environment.bash"
+
+setup() {
+    clear_git_local_env
+    TEST_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+@test "pre-push clears repository-local Git environment without mutating caller config" {
+    local workspace="$TEST_DIR/workspace"
+    local fake_bin="$TEST_DIR/bin"
+    local calls="$TEST_DIR/cargo-calls"
+    local config_before="$TEST_DIR/config-before"
+    mkdir -p "$workspace" "$fake_bin"
+    printf '[workspace]\nmembers = []\n' >"$workspace/Cargo.toml"
+    git -C "$workspace" init --quiet
+    cp "$workspace/.git/config" "$config_before"
+
+    cat >"$fake_bin/cargo" <<'EOF'
+#!/bin/bash
+set -e
+while IFS= read -r git_env_var; do
+    if [[ "$git_env_var" =~ ^[A-Z0-9_]+$ ]] && env | grep -q "^${git_env_var}="; then
+        echo "${git_env_var} leaked into cargo" >&2
+        exit 97
+    fi
+done < <(git rev-parse --local-env-vars)
+git rev-parse --show-toplevel
+printf '%s\n' "$*" >>"$META_TEST_CARGO_CALLS"
+EOF
+    chmod +x "$fake_bin/cargo"
+
+    cd "$workspace"
+    run env \
+        PATH="$fake_bin:$PATH" \
+        META_TEST_CARGO_CALLS="$calls" \
+        GIT_DIR="$workspace/.git" \
+        GIT_WORK_TREE="$workspace" \
+        GIT_INDEX_FILE="$workspace/.git/index" \
+        sh "$BATS_TEST_DIRNAME/../.githooks/pre-push"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$workspace"* ]]
+    [ "$(wc -l <"$calls" | tr -d ' ')" -eq 3 ]
+    cmp -s "$config_before" "$workspace/.git/config"
+}

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -49,3 +49,27 @@ EOF
     [ "$(wc -l <"$calls" | tr -d ' ')" -eq 3 ]
     cmp -s "$config_before" "$workspace/.git/config"
 }
+
+@test "Git test environment helper fails closed when enumeration fails" {
+    local fake_bin="$TEST_DIR/bin"
+    local real_git
+    real_git="$(command -v git)"
+    mkdir -p "$fake_bin"
+
+    cat >"$fake_bin/git" <<'EOF'
+#!/bin/bash
+if [[ "$1" == "rev-parse" && "$2" == "--local-env-vars" ]]; then
+    exit 73
+fi
+exec "$META_TEST_REAL_GIT" "$@"
+EOF
+    chmod +x "$fake_bin/git"
+
+    run env \
+        PATH="$fake_bin:$PATH" \
+        META_TEST_REAL_GIT="$real_git" \
+        bash -c 'source "$1"; clear_git_local_env' _ "$BATS_TEST_DIRNAME/helpers/git_environment.bash"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Could not determine repository-local Git environment"* ]]
+}

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -1,8 +1,11 @@
 #!/usr/bin/env bats
 
+load "${BATS_TEST_DIRNAME}/helpers/git_environment.bash"
+
 # Integration tests for `meta init claude`
 
 setup() {
+    clear_git_local_env
     META_BIN="$BATS_TEST_DIRNAME/../target/debug/meta"
 
     if [ ! -f "$META_BIN" ]; then

--- a/tests/plugin_install.bats
+++ b/tests/plugin_install.bats
@@ -1,8 +1,11 @@
 #!/usr/bin/env bats
 
+load "${BATS_TEST_DIRNAME}/helpers/git_environment.bash"
+
 # Integration tests for `meta plugin install`
 
 setup() {
+    clear_git_local_env
     META_BIN="$BATS_TEST_DIRNAME/../target/debug/meta"
 
     if [ ! -f "$META_BIN" ]; then

--- a/tests/project_list.bats
+++ b/tests/project_list.bats
@@ -1,8 +1,11 @@
 #!/usr/bin/env bats
 
+load "${BATS_TEST_DIRNAME}/helpers/git_environment.bash"
+
 # Integration tests for `meta project list` / `meta project ls`
 
 setup() {
+    clear_git_local_env
     # Build binaries if not already built
     META_BIN="$BATS_TEST_DIRNAME/../target/debug/meta"
     META_PROJECT_BIN="$BATS_TEST_DIRNAME/../target/debug/meta-project"

--- a/tests/worktree.bats
+++ b/tests/worktree.bats
@@ -1,9 +1,12 @@
 #!/usr/bin/env bats
 
+load "${BATS_TEST_DIRNAME}/helpers/git_environment.bash"
+
 # Integration tests for `meta git worktree` subcommand
 # Tests: create, add, list, status, diff, exec, remove, configuration, edge cases
 
 setup() {
+    clear_git_local_env
     META_BIN="$BATS_TEST_DIRNAME/../target/debug/meta"
     META_GIT_BIN="$BATS_TEST_DIRNAME/../target/debug/meta-git"
 
@@ -101,6 +104,18 @@ EOF
     [ "$status" -eq 0 ]
     BRANCH=$(git -C ".worktrees/myfix/backend" branch --show-current)
     [ "$BRANCH" = "fix/the-bug" ]
+}
+
+@test "worktree create reports corrupt bare config with scoped repair" {
+    git -C backend config --local core.bare true
+
+    run "$META_BIN" git worktree create corrupt-source --repo backend
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"core.bare=true"* ]]
+    [[ "$output" == *"/backend"* ]]
+    [[ "$output" == *"config --local core.bare false"* ]]
+    [ ! -e ".worktrees/corrupt-source/backend" ]
 }
 
 @test "worktree create --all creates worktrees for all repos" {

--- a/tests/worktree_cloud.bats
+++ b/tests/worktree_cloud.bats
@@ -1,10 +1,13 @@
 #!/usr/bin/env bats
 
+load "${BATS_TEST_DIRNAME}/helpers/git_environment.bash"
+
 # Integration tests for `meta git worktree` cloud/agent extensions (meta-6)
 # Tests: --meta, --ephemeral, --ttl, --from-ref, prune, lifecycle hooks,
 #         context detection, ephemeral exec, centralized store
 
 setup() {
+    clear_git_local_env
     META_BIN="$BATS_TEST_DIRNAME/../target/debug/meta"
     META_GIT_BIN="$BATS_TEST_DIRNAME/../target/debug/meta-git"
 

--- a/tests/worktree_edge_cases.bats
+++ b/tests/worktree_edge_cases.bats
@@ -1,9 +1,12 @@
 #!/usr/bin/env bats
 
+load "${BATS_TEST_DIRNAME}/helpers/git_environment.bash"
+
 # Integration tests for meta git worktree edge cases (Phase 2 & 3)
 # Tests: strict mode, prune with orphan detection, cache invalidation, ahead/behind
 
 setup() {
+    clear_git_local_env
     META_BIN="$BATS_TEST_DIRNAME/../target/debug/meta"
     META_GIT_BIN="$BATS_TEST_DIRNAME/../target/debug/meta-git"
 


### PR DESCRIPTION
## Summary

- clear repository-local Git variables in the shared pre-push hook before invoking Cargo
- centralize sanitized Git test setup and use explicit bare fixture repositories
- add hook and worktree regressions that verify caller config cannot be mutated

## Root cause

The shared hook and BATS fixtures inherited `GIT_DIR`, `GIT_WORK_TREE`, and related repository-local variables from the invoking checkout. Fixture Git commands could consequently target the caller's shared config and flip `core.bare` in a normal worktree repository.

## Testing

- `cargo test --workspace`
- `cargo clippy -p meta_git_lib --all-targets --no-deps -- -D warnings`
- full BATS suite: 324 passed; the existing empty-PATH plugin test remains environment-dependent because Homebrew-installed `meta-git` and `meta-project` are discoverable

## Tracking

- `[[tasks/harden-git-hook-repository-environment]]`
- `[[incidents/git-core-bare-corruption-in-worktree-repositories]]`